### PR TITLE
[feat] #6 이미지 캐싱 구현

### DIFF
--- a/Dramatic/Core/Network/Foundation/ImageClient.swift
+++ b/Dramatic/Core/Network/Foundation/ImageClient.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 import Alamofire
-import RxSwift
 
 final class ImageClient {
     

--- a/Dramatic/Core/Network/Foundation/ImageClient.swift
+++ b/Dramatic/Core/Network/Foundation/ImageClient.swift
@@ -1,0 +1,57 @@
+//
+//  ImageClient.swift
+//  Dramatic
+//
+//  Created by 이빈 on 3/21/25.
+//
+
+import Foundation
+
+import Alamofire
+import RxSwift
+
+final class ImageClient {
+    
+    static let shared = ImageClient()
+    
+    private let session: Session
+    
+    private let memoryCapacity = 10 * 1024 * 1024 // ram에 저장 가능한 최대 크기
+    private let diskCapacity = 100 * 1024 * 1024 // 디스크에 저장 가능한 최대 크기
+    
+    private init() {
+        let urlCache = URLCache(
+            memoryCapacity: memoryCapacity,
+            diskCapacity: diskCapacity,
+            diskPath: "imageCache" // 디스크에 저장될 경로
+        )
+        
+        let config = URLSessionConfiguration.default
+        config.urlCache = urlCache
+        config.requestCachePolicy = .returnCacheDataElseLoad // 캐시 된 데이터가 있으면 사용
+        
+        session = Session(configuration: config)
+    }
+    
+    func requestImage(with url: URL, handler: @escaping (Result<Data, AFError>) -> Void) {
+        
+        let request = URLRequest(url: url)
+        
+        if let cached = URLCache.shared.cachedResponse(for: request) {
+            handler(.success(cached.data))
+            return
+        }
+        
+        let task = session.request(url)
+            .validate(statusCode: 200..<300)
+            .responseData { response in
+                switch response.result {
+                case .success(let data):
+                    handler(.success(data))
+                case .failure(let error):
+                    handler(.failure(error))
+                }
+            }
+    }
+    
+}

--- a/Dramatic/Util/Extension/UIImageView+.swift
+++ b/Dramatic/Util/Extension/UIImageView+.swift
@@ -1,0 +1,25 @@
+//
+//  UIImageView+.swift
+//  Dramatic
+//
+//  Created by 이빈 on 3/21/25.
+//
+
+import UIKit
+
+extension UIImageView {
+    
+    func setImage(with url: String) {
+        guard let url = URL(string: url) else { return }
+        
+        ImageClient.shared.requestImage(with: url) { response in
+            switch response {
+            case .success(let data):
+                self.image = UIImage(data: data)
+            case .failure(_):
+                self.image = UIImage(systemName: "arrow.down.app.dashed.trianglebadge.exclamationmark")
+            }
+        }
+    }
+    
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #6 

## 📝작업 내용
### ImageClient
`URLCache`를 활용하여 이미지 캐싱을 구현하였습니다.
`returnCacheDataElseLoad` 설정을 통해, 캐시된 데이터가 있으면 그대로 사용하고, 없으면 URL을 통해 데이터를 가져옵니다.
(메모리 캐시 확인 > (캐시가 없으먼)디스크 캐시 확인 > (캐시가 없으면)이미지 요청)

### UIImageView 확장
ImageClient를 활용한 이미지 적용 함수를 UIImageView 확장으로 구현했습니다.
(이미지 다운에 실패할 경우, 아래 sfsymbol로 대체하였습니다.)
![스크린샷 2025-03-21 오후 2 15 08](https://github.com/user-attachments/assets/ef8a8178-cc98-4905-8bef-9eb8b06d09fa)

### 사용 예시
```Swift
let imageView = UIImageView()
imageView.setImage(with: "서버에서 받아온 이미지 URL 문자열")
```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
### ImageClient의 Cache 용량
현재, 메모리 용량을 10MB, 디스크 용량을 100MB로 잡았는데 적당한 용량인지 잘 모르겠습니다.
보통 이 부분은 나중에 네트워크 통신에서 이미지 용량을 확인해보고 수정하나요?

close #6 
