### PR TITLE
[feat] #5 DTDramaHorizontalCollectionView 구현

### DIFF
--- a/Dramatic/DSKit/Component/DTCellTitle.swift
+++ b/Dramatic/DSKit/Component/DTCellTitle.swift
@@ -53,6 +53,12 @@ final class DTCellTitle: BaseView {
             make.bottom.horizontalEdges.equalToSuperview()
         }
     }
+    
+    func setTitle(_ title: String, content: String) {
+        titleLabel.text = title
+        contentLabel.text = content
+    }
+
 }
 
 @available(iOS 17.0, *)

--- a/Dramatic/DSKit/Component/DTDramaHorizontalCollectionView.swift
+++ b/Dramatic/DSKit/Component/DTDramaHorizontalCollectionView.swift
@@ -1,0 +1,162 @@
+//
+//  DTDramaHorizontalCollectionView.swift
+//  Dramatic
+//
+//  Created by 이빈 on 3/21/25.
+//
+
+import UIKit
+import SnapKit
+
+struct Drama {
+    let title: String
+    let content: String
+    let imageURL: String
+}
+
+// MARK: - DTCardType
+enum DTCardType {
+    case drama
+    case episode
+    
+    var imageWidth: CGFloat {
+        switch self {
+        case .drama: return 140
+        case .episode: return 150
+        }
+    }
+    
+    var imageHeight: CGFloat {
+        switch self {
+        case .drama: return 100
+        case .episode: return 200
+        }
+    }
+    
+    var titleHeight: CGFloat {
+        return 50
+    }
+    
+    var offset: CGFloat {
+        switch self {
+        case .drama: return 5
+        case .episode: return 2
+        }
+    }
+    
+    var totalHeight: CGFloat {
+        return imageHeight + titleHeight + offset
+    }
+}
+
+// MARK: - DTDramaHorizontalCollectionView
+final class DTDramaHorizontalCollectionView: BaseView {
+    
+    private let size: DTCardType
+    
+    let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
+    
+    init(size: DTCardType) {
+        self.size = size
+        super.init(frame: .zero)
+    }
+    
+    override func configureHierarchy() {
+        addSubview(collectionView)
+    }
+    
+    override func configureLayout() {
+        collectionView.snp.makeConstraints { make in
+            make.top.horizontalEdges.equalToSuperview()
+            make.height.equalTo(size.totalHeight)
+        }
+    }
+    
+    override func configureView() {
+        collectionView.register(
+            DTDramaHorizontalCollectionViewCell.self,
+            forCellWithReuseIdentifier: DTDramaHorizontalCollectionViewCell.identifier
+        )
+        
+        collectionView.collectionViewLayout = configureCollectionViewLayout(width: size.imageWidth, height: size.totalHeight)
+        
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.backgroundColor = .clear
+    }
+    
+    private func configureCollectionViewLayout(width: Double, height: Double) -> UICollectionViewLayout {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        layout.minimumInteritemSpacing = 15
+        layout.sectionInset = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 15)
+        layout.itemSize = CGSize(width: width, height: height)
+        return layout
+    }
+    
+}
+
+// MARK: - DTDramaHorizontalCollectionViewCell
+final class DTDramaHorizontalCollectionViewCell: BaseCollectionViewCell {
+    
+    static let identifier = "DTDramaHorizontalCollectionViewCell"
+    
+    private var type: DTCardType = .drama
+
+    private let imageContentView = UIView()
+    private let imageView = UIImageView()
+    private let titleView = DTCellTitle(title: "", content: "")
+    
+    override func configureHierarchy() {
+        imageContentView.addSubview(imageView)
+        
+        contentView.addSubViews(
+            imageContentView,
+            titleView
+        )
+    }
+
+    override func configureLayout() {
+        imageContentView.snp.makeConstraints { make in
+            make.top.horizontalEdges.equalToSuperview()
+            make.height.equalTo(type.imageHeight)
+        }
+
+        imageView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+
+        titleView.snp.makeConstraints { make in
+            make.top.equalTo(imageContentView.snp.bottom).offset(type.offset)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(type.titleHeight)
+        }
+    }
+
+    override func configureView() {
+        imageContentView.clipsToBounds = true
+        imageContentView.layer.cornerRadius = 5
+        imageView.contentMode = .scaleAspectFill
+    }
+
+    func configure(drama: Drama, cardType: DTCardType) {
+        type = cardType
+        titleView.setTitle(drama.title, content: drama.content)
+        imageView.setImage(with: drama.imageURL)
+        
+        updateLayout()
+    }
+    
+    private func updateLayout() {
+        imageContentView.snp.remakeConstraints { make in
+            make.top.horizontalEdges.equalToSuperview()
+            make.height.equalTo(type.imageHeight)
+        }
+        
+        titleView.snp.makeConstraints { make in
+            make.top.equalTo(imageContentView.snp.bottom).offset(type.offset)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(type.titleHeight)
+        }
+    }
+}

--- a/Dramatic/DSKit/Component/DTDramaHorizontalCollectionView.swift
+++ b/Dramatic/DSKit/Component/DTDramaHorizontalCollectionView.swift
@@ -8,77 +8,65 @@
 import UIKit
 import SnapKit
 
-struct Drama {
-    let title: String
-    let content: String
-    let imageURL: String
-}
-
-// MARK: - DTCardType
-enum DTCardType {
-    case drama
-    case episode
-    
-    var imageWidth: CGFloat {
-        switch self {
-        case .drama: return 140
-        case .episode: return 150
-        }
-    }
-    
-    var imageHeight: CGFloat {
-        switch self {
-        case .drama: return 100
-        case .episode: return 200
-        }
-    }
-    
-    var titleHeight: CGFloat {
-        return 50
-    }
-    
-    var offset: CGFloat {
-        switch self {
-        case .drama: return 5
-        case .episode: return 2
-        }
-    }
-    
-    var totalHeight: CGFloat {
-        return imageHeight + titleHeight + offset
-    }
-}
-
 // MARK: - DTDramaHorizontalCollectionView
 final class DTDramaHorizontalCollectionView: BaseView {
     
-    private let size: DTCardType
-    
+    // MARK: - DTCardType
+    enum DTCardType {
+        case drama
+        case episode
+        
+        var imageWidth: CGFloat {
+            switch self {
+            case .drama: return 140
+            case .episode: return 150
+            }
+        }
+        
+        var imageHeight: CGFloat {
+            switch self {
+            case .drama: return 100
+            case .episode: return 200
+            }
+        }
+        
+        var titleHeight: CGFloat {
+            return 50
+        }
+        
+        var offset: CGFloat {
+            switch self {
+            case .drama: return 5
+            case .episode: return 2
+            }
+        }
+        
+        var totalHeight: CGFloat {
+            return imageHeight + titleHeight + offset
+        }
+    }
+
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
     
     init(size: DTCardType) {
-        self.size = size
         super.init(frame: .zero)
-    }
-    
-    override func configureHierarchy() {
-        addSubview(collectionView)
-    }
-    
-    override func configureLayout() {
+        collectionView.collectionViewLayout = configureCollectionViewLayout(width: size.imageWidth, height: size.totalHeight)
+        
         collectionView.snp.makeConstraints { make in
             make.top.horizontalEdges.equalToSuperview()
             make.height.equalTo(size.totalHeight)
         }
     }
     
+    override func configureHierarchy() {
+        addSubview(collectionView)
+    }
+
     override func configureView() {
         collectionView.register(
             DTDramaHorizontalCollectionViewCell.self,
             forCellWithReuseIdentifier: DTDramaHorizontalCollectionViewCell.identifier
         )
-        
-        collectionView.collectionViewLayout = configureCollectionViewLayout(width: size.imageWidth, height: size.totalHeight)
         
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.showsVerticalScrollIndicator = false
@@ -101,7 +89,7 @@ final class DTDramaHorizontalCollectionViewCell: BaseCollectionViewCell {
     
     static let identifier = "DTDramaHorizontalCollectionViewCell"
     
-    private var type: DTCardType = .drama
+    private var type: DTDramaHorizontalCollectionView.DTCardType = .drama
 
     private let imageContentView = UIView()
     private let imageView = UIImageView()
@@ -139,7 +127,7 @@ final class DTDramaHorizontalCollectionViewCell: BaseCollectionViewCell {
         imageView.contentMode = .scaleAspectFill
     }
 
-    func configure(drama: Drama, cardType: DTCardType) {
+    func configure(drama: DramaDisplayable, cardType: DTDramaHorizontalCollectionView.DTCardType) {
         type = cardType
         titleView.setTitle(drama.title, content: drama.content)
         imageView.setImage(with: drama.imageURL)

--- a/Dramatic/Model/Drama/DramaDTO.swift
+++ b/Dramatic/Model/Drama/DramaDTO.swift
@@ -1,0 +1,14 @@
+//
+//  DramaDTO.swift
+//  Dramatic
+//
+//  Created by 이빈 on 3/22/25.
+//
+
+import Foundation
+
+struct DramaDTO: Decodable, DramaDisplayable {
+    let title: String
+    let content: String
+    let imageURL: String
+}

--- a/Dramatic/Model/Drama/DramaDisplayable.swift
+++ b/Dramatic/Model/Drama/DramaDisplayable.swift
@@ -1,0 +1,14 @@
+//
+//  DramaDisplayable.swift
+//  Dramatic
+//
+//  Created by 이빈 on 3/22/25.
+//
+
+import Foundation
+
+protocol DramaDisplayable {
+    var title: String { get }
+    var content: String { get }
+    var imageURL: String { get }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #5 

## 📝작업 내용

#### DTDramaHorizontalCollectionView 구현
> **DTCardType**

홈화면과 보관함 화면에 사용되는 drama 케이스,
드라마 화면에 사용되는 episode 케이스를 만들어, 사이즈를 지정해주었습니다.
컬렉션뷰를 생성할 때, `DTCardType`을 지정하여 두 케이스에 대한 사이즈 조절을 할 수 있게 설정해 놓았습니다.

> **사용 예시**

```Swift
private let size = DTDramaHorizontalCollectionView.DTCardType.episode // 케이스 선택
private lazy var horizontalCollectionView = DTDramaHorizontalCollectionView(size: size)

horizontalCollectionView.snp.makeConstraints { make in
        make.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(20)
        make.horizontalEdges.equalToSuperview()
        make.height.equalTo(size.totalHeight) // 레이아웃 높이를 선택한 케이스의 totalHeight으로 지정
}
```

#### DTCellTitle의 setTitle 메서드 추가
> **setTitle 메서드**

`DTDramaHorizontalCollectionView`에서 사용되는 DTCellTitle의 경우, 각 셀의 데이터에 맞게 추후에 업데이트할 수 있도록 메서드를 추가하였습니다.

### 스크린샷 (선택)
> **`drama` 케이스의 `DTDramaHorizontalCollectionView`**

![Simulator Screen Recording - iPhone 16 Pro - 2025-03-22 at 16 09 46](https://github.com/user-attachments/assets/192fd26b-3d31-45cf-833c-f3dc35e184a4)


> **`episode` 케이스의 `DTDramaHorizontalCollectionView`**

![Simulator Screen Recording - iPhone 16 Pro - 2025-03-22 at 16 12 13](https://github.com/user-attachments/assets/ade388df-7346-446a-a6c6-f1ec70187b3f)


## 💬리뷰 요구사항(선택)

#### DTDramaHorizontalCollectionView
> **DTCardType의 코드 위치**
`DTCardType`을 일단 컬렉션뷰 파일 내부에 작성해두었는데, 다른 파일에서도 사용될 수 있기 때문에 따로 빼두는게 좋을까요?

> **셀에 표시될 데이터**
현재, 셀에 표시될 데이터(타이틀, 컨텐트, 이미지 URL)를 `Drama`로 임시로 설정해 두었습니다. 홈 화면 구현 브랜치에서, DTO 설정 및 현재 코드 수정을 한꺼번에 하고 그 브랜치에서 PR 올리는 방식으로 해도 괜찮을까요?

close #5 
