### PR TITLE
[feat] #18 검색 화면 구현

### DIFF
--- a/Dramatic/Core/Network/Drama/DramaClient.swift
+++ b/Dramatic/Core/Network/Drama/DramaClient.swift
@@ -52,4 +52,13 @@ final class DramaClient {
             }
     }
     
+    func fetchSearchDrama(page: Int, keyword: String?) -> Single<PageDTO> {
+        guard let keyword else { return Single.just(PageDTO.empty) }
+        
+        return provider.request(.search(page: page, keyword: keyword))
+            .catch { error in
+                return Single.just(PageDTO.empty)
+            }
+    }
+    
 }

--- a/Dramatic/Core/Network/Drama/DramaEndpoint.swift
+++ b/Dramatic/Core/Network/Drama/DramaEndpoint.swift
@@ -15,6 +15,7 @@ enum DramaEndpoint: EndPoint {
     case rated
     case similar(id: Int)
     case recommend(id: Int)
+    case search(page: Int, keyword: String)
     
     
     var baseURL: URL? { return URL(string: Bundle.main.baseURL) }
@@ -31,6 +32,8 @@ enum DramaEndpoint: EndPoint {
             return "/tv/\(id)/similar"
         case .recommend(let id):
             return "/tv/\(id)/recommendations"
+        case .search:
+            return "/search/tv"
         }
     }
     
@@ -64,6 +67,12 @@ enum DramaEndpoint: EndPoint {
             return RequestParameters(language: "ko-KR")
         case .recommend:
             return RequestParameters(language: "ko-KR")
+        case .search(let page, let keyword):
+            return DramaSearchRequest(
+                language: "ko-KR",
+                query: keyword,
+                page: page
+            )
         }
     }
     
@@ -75,4 +84,10 @@ enum DramaEndpoint: EndPoint {
 }
 struct RequestParameters: Encodable {
     let language: String
+}
+
+struct DramaSearchRequest: Encodable {
+    let language: String
+    let query: String
+    let page: Int
 }

--- a/Dramatic/DSKit/Component/DTSearchBar.swift
+++ b/Dramatic/DSKit/Component/DTSearchBar.swift
@@ -36,7 +36,6 @@ final class DTSearchBar: BaseView {
     override func configureLayout() {
         stackView.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview().inset(10)
-            make.centerY.equalToSuperview()
             make.height.equalTo(50)
         }
     }

--- a/Dramatic/DSKit/Component/DTTabButton.swift
+++ b/Dramatic/DSKit/Component/DTTabButton.swift
@@ -1,0 +1,8 @@
+//
+//  DTTabButton.swift
+//  Dramatic
+//
+//  Created by 이빈 on 3/24/25.
+//
+
+import Foundation

--- a/Dramatic/DSKit/Component/DTTabButton.swift
+++ b/Dramatic/DSKit/Component/DTTabButton.swift
@@ -5,4 +5,62 @@
 //  Created by 이빈 on 3/24/25.
 //
 
-import Foundation
+import UIKit
+import SnapKit
+
+final class DTTabButton: UIButton {
+    
+    private var title: String
+    
+    private let stackView = UIStackView()
+    private let button = UIButton()
+    private let underLineView = UIView()
+    
+    init(title: String) {
+        self.title = title
+        super.init(frame: .zero)
+        configureHierarchy()
+        configureLayout()
+        configureView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configureHierarchy() {
+        stackView.addArrangedSubviews(button, underLineView)
+        addSubview(stackView)
+    }
+    
+    private func configureLayout() {
+        stackView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        underLineView.snp.makeConstraints { make in
+            make.horizontalEdges.equalToSuperview()
+            make.height.equalTo(1)
+        }
+    }
+    
+    private func configureView() {
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.distribution = .fill
+        
+        button.setTitle(title, for: .normal)
+        button.setTitleColor(.dt(.semantic(.text(.secondary))), for: .normal)
+        button.setTitleColor(.dt(.primitive(.white)), for: .selected)
+        button.titleLabel?.font = .dt(.headline)
+        button.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+        
+        underLineView.backgroundColor = .dt(.primitive(.white))
+        underLineView.isHidden = true
+    }
+    
+    @objc private func buttonTapped() {
+        button.isSelected.toggle()
+        underLineView.isHidden = !button.isSelected
+    }
+}

--- a/Dramatic/Feature/Search/PosterCollectionViewCell.swift
+++ b/Dramatic/Feature/Search/PosterCollectionViewCell.swift
@@ -1,0 +1,8 @@
+//
+//  SearchCollectionViewCell.swift
+//  Dramatic
+//
+//  Created by 이빈 on 3/24/25.
+//
+
+import Foundation

--- a/Dramatic/Feature/Search/PosterCollectionViewCell.swift
+++ b/Dramatic/Feature/Search/PosterCollectionViewCell.swift
@@ -1,8 +1,33 @@
 //
-//  SearchCollectionViewCell.swift
+//  PosterCollectionViewCell.swift
 //  Dramatic
 //
 //  Created by 이빈 on 3/24/25.
 //
 
-import Foundation
+import UIKit
+import SnapKit
+
+final class PosterCollectionViewCell: BaseCollectionViewCell {
+    
+    static let identifier = "PosterCollectionViewCell"
+    let imageView = UIImageView()
+    
+    override func configureHierarchy() {
+        contentView.addSubview(imageView)
+    }
+    
+    override func configureLayout() {
+        imageView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+    
+    override func configureView() {
+        imageView.clipsToBounds = true
+        imageView.layer.cornerRadius = 5
+        imageView.contentMode = .scaleAspectFill
+        imageView.tintColor = .dt(.primitive(.gray))
+    }
+    
+}

--- a/Dramatic/Feature/Search/SearchNavigationBar.swift
+++ b/Dramatic/Feature/Search/SearchNavigationBar.swift
@@ -1,8 +1,0 @@
-//
-//  SearchNavigationBar.swift
-//  Dramatic
-//
-//  Created by 이빈 on 3/24/25.
-//
-
-import Foundation

--- a/Dramatic/Feature/Search/SearchNavigationBar.swift
+++ b/Dramatic/Feature/Search/SearchNavigationBar.swift
@@ -1,0 +1,8 @@
+//
+//  SearchNavigationBar.swift
+//  Dramatic
+//
+//  Created by 이빈 on 3/24/25.
+//
+
+import Foundation

--- a/Dramatic/Feature/Search/SearchView.swift
+++ b/Dramatic/Feature/Search/SearchView.swift
@@ -5,4 +5,85 @@
 //  Created by 이빈 on 3/24/25.
 //
 
-import Foundation
+import UIKit
+import SnapKit
+
+final class SearchView: BaseView {
+    
+    let searchBar = DTSearchBar(with: "드라마를 검색해 보세요.")
+    
+    private let stackView = UIStackView()
+    private let popularButton = DTTabButton(title: "인기")
+    private let actorButton = DTTabButton(title: "배우 및 제작진")
+    private let programButton = DTTabButton(title: "TV 프로그램")
+    private let movieButton = DTTabButton(title: "영화")
+
+    let posterCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        posterCollectionView.collectionViewLayout = configureCollectionViewLayout()
+    }
+    
+    override func configureHierarchy() {
+        stackView.addArrangedSubviews(
+            popularButton,
+            actorButton,
+            programButton,
+            movieButton
+        )
+        
+        addSubViews(
+            searchBar,
+            stackView,
+            posterCollectionView
+        )
+    }
+    
+    override func configureLayout() {
+        searchBar.snp.makeConstraints { make in
+            make.top.equalTo(safeAreaLayoutGuide)
+            make.horizontalEdges.equalToSuperview()
+            make.height.equalTo(50)
+        }
+        
+        stackView.snp.makeConstraints { make in
+            make.top.equalTo(searchBar.snp.bottom).offset(5)
+            make.leading.equalToSuperview().inset(20)
+        }
+        
+        posterCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(stackView.snp.bottom)
+            make.horizontalEdges.bottom.equalToSuperview()
+        }
+    }
+    
+    override func configureView() {
+        backgroundColor = .dt(.primitive(.black))
+        
+        stackView.axis = .horizontal
+        stackView.alignment = .leading
+        stackView.spacing = 10
+        
+        posterCollectionView.showsVerticalScrollIndicator = false
+        posterCollectionView.showsHorizontalScrollIndicator = false
+        posterCollectionView.backgroundColor = .dt(.primitive(.black))
+        
+        posterCollectionView.register(PosterCollectionViewCell.self, forCellWithReuseIdentifier: PosterCollectionViewCell.identifier)
+        
+    }
+    
+    private func configureCollectionViewLayout() -> UICollectionViewFlowLayout {
+        let layout = UICollectionViewFlowLayout()
+        let spacing: CGFloat = 10
+        let deviceWidth = frame.width
+        let itemSize = floor((deviceWidth - (4 * spacing)) / 3)
+        layout.scrollDirection = .vertical
+        layout.minimumLineSpacing = spacing
+        layout.minimumInteritemSpacing = spacing
+        layout.sectionInset = UIEdgeInsets(top: 0, left: spacing, bottom: 0, right: spacing)
+        layout.itemSize = CGSize(width: itemSize, height: itemSize * 1.5)
+        return layout
+    }
+    
+}

--- a/Dramatic/Feature/Search/SearchView.swift
+++ b/Dramatic/Feature/Search/SearchView.swift
@@ -1,0 +1,8 @@
+//
+//  SearchView.swift
+//  Dramatic
+//
+//  Created by 이빈 on 3/24/25.
+//
+
+import Foundation

--- a/Dramatic/Feature/Search/SearchViewController.swift
+++ b/Dramatic/Feature/Search/SearchViewController.swift
@@ -1,0 +1,8 @@
+//
+//  SearchViewController.swift
+//  Dramatic
+//
+//  Created by 이빈 on 3/24/25.
+//
+
+import Foundation

--- a/Dramatic/Feature/Search/SearchViewController.swift
+++ b/Dramatic/Feature/Search/SearchViewController.swift
@@ -5,4 +5,56 @@
 //  Created by 이빈 on 3/24/25.
 //
 
-import Foundation
+import UIKit
+import RxSwift
+import ReactorKit
+
+final class SearchViewController: BaseViewController<SearchView> {
+    
+    var disposeBag = DisposeBag()
+
+    override func configureNavigation() {
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.reactor = SearchViewModel()
+    }
+
+}
+
+extension SearchViewController: View {
+    
+    func bind(reactor: SearchViewModel) {
+        // 검색
+        mainView.searchBar.searchBar.rx.searchButtonClicked
+            .withUnretained(self)
+            .map { owner, _ in (1, owner.mainView.searchBar.searchBar.text) }
+            .map { Reactor.Action.loadSearchData(page: $0.0, keyword: $0.1) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        // 셀 선택
+        mainView.posterCollectionView.rx.modelSelected(DramaDisplayable.self)
+            .map { Reactor.Action.selectDrama(id: $0.id) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        // 결과 데이터 반영
+        reactor.pulse(\.$searchDrama)
+            .bind(to: mainView.posterCollectionView.rx.items(cellIdentifier: PosterCollectionViewCell.identifier, cellType: PosterCollectionViewCell.self)) { (row, element, cell) in
+                cell.imageView.setImage(with: element.imageURL)
+            }
+            .disposed(by: disposeBag)
+        
+        // 셀 선택: 화면 전환
+        reactor.state
+            .map { $0.selectedDrama }
+            .bind(with: self) { owner, id in
+                print("화면전환 아이디: \(id)")
+            }
+            .disposed(by: disposeBag)
+    }
+
+}

--- a/Dramatic/Feature/Search/SearchViewModel.swift
+++ b/Dramatic/Feature/Search/SearchViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  SearchViewModel.swift
+//  Dramatic
+//
+//  Created by 이빈 on 3/24/25.
+//
+
+import Foundation

--- a/Dramatic/Feature/Search/SearchViewModel.swift
+++ b/Dramatic/Feature/Search/SearchViewModel.swift
@@ -6,3 +6,51 @@
 //
 
 import Foundation
+import RxSwift
+import ReactorKit
+
+final class SearchViewModel: Reactor {
+    
+    enum Action {
+        case loadSearchData(page: Int, keyword: String?)
+        case selectDrama(id: Int)
+    }
+    
+    enum Mutation {
+        case setSearchDrama(dramas: [DramaDisplayable])
+        case setSelectedDrama(id: Int)
+    }
+    
+    struct State {
+        @Pulse var searchDrama: [DramaDisplayable]
+        var selectedDrama: Int?
+    }
+    
+    let initialState: State
+    
+    init() {
+        self.initialState = State(searchDrama: [])
+    }
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .loadSearchData(let page, let keyword):
+            return DramaClient.shared.fetchSearchDrama(page: page, keyword: keyword)
+                .map { Mutation.setSearchDrama(dramas: $0.results.map { $0.toEntity() }) }
+                .asObservable()
+            
+        case .selectDrama(let id):
+            return Observable.just(Mutation.setSelectedDrama(id: id))
+        }
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case .setSearchDrama(let dramas): newState.searchDrama = dramas
+        case .setSelectedDrama(let id): newState.selectedDrama = id
+        }
+        return newState
+    }
+    
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #18 

## 📝작업 내용

### **DTTabButton 컴포넌트 구현**
검색화면의 상단 탭 부분의 버튼을 `DTTabButton` 컴포넌트로 구현하였습니다.

### **검색 엔드포인트 추가**
기존 `DramaEndpoint`에 검색 엔드포인트 추가 및 `DramaClient`에 fetch 함수를 추가하였습니다.
(추후 페이지네이션 추가를 고려하여, page 파라미터를 넣어놓았습니다)

### **ViewController / ViewModel**
- `searchButtonClicked` -> 네트워크 통신 
- `posterCollectionView` 셀 탭 -> 화면 전환
위 두 기능을 구현했습니다.

### 스크린샷 (선택)
![Simulator Screen Recording - iPhone 16 Pro - 2025-03-24 at 21 40 15](https://github.com/user-attachments/assets/e8c04e4a-89c9-4bc1-8474-d5f080ea095f)

## 💬리뷰 요구사항(선택)

close #18 
