### PR TITLE
[feat] #20 보관함 화면 구현

### DIFF
--- a/Dramatic/DSKit/Component/DTArchiveStatusView.swift
+++ b/Dramatic/DSKit/Component/DTArchiveStatusView.swift
@@ -1,0 +1,50 @@
+//
+//  DTArchiveStatusView.swift
+//  Dramatic
+//
+//  Created by 이빈 on 3/25/25.
+//
+
+import UIKit
+import SnapKit
+
+final class DTArchiveStatusView: BaseView {
+    
+    private let stackView = UIStackView()
+    let countLabel = UILabel()
+    private let statusTitle = UILabel()
+    
+    private var title: String
+    private var color: UIColor
+    
+    init(title: String, color: UIColor = .dt(.semantic(.text(.secondary)))) {
+        self.title = title
+        self.color = color
+        super.init(frame: .zero)
+    }
+    
+    override func configureHierarchy() {
+        stackView.addArrangedSubviews(countLabel, statusTitle)
+        addSubview(stackView)
+    }
+    
+    override func configureLayout() {
+        stackView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+    
+    override func configureView() {
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.spacing = 15
+        
+        countLabel.font = .dt(.title)
+        countLabel.textColor = color
+        
+        statusTitle.text = title
+        statusTitle.font = .dt(.body)
+        statusTitle.textColor = color
+    }
+    
+}

--- a/Dramatic/Feature/Library/LibraryView.swift
+++ b/Dramatic/Feature/Library/LibraryView.swift
@@ -27,9 +27,6 @@ final class LibraryView: BaseView {
     let watchingHeader = DTHeader(title: "보는중")
     lazy var watchingCollectionView = DTDramaHorizontalCollectionView(size: size)
     
-    let a = DTHeader(title: "보는중")
-    lazy var aCollectionView = DTDramaHorizontalCollectionView(size: size)
-    
     private let size = DTDramaHorizontalCollectionView.DTCardType.drama
     
     override func configureHierarchy() {
@@ -46,9 +43,7 @@ final class LibraryView: BaseView {
             watchedHeader,
             watchedCollectionView,
             watchingHeader,
-            watchingCollectionView,
-            a,
-            aCollectionView
+            watchingCollectionView
         )
         
         scrollView.addSubview(contentView)

--- a/Dramatic/Feature/Library/LibraryView.swift
+++ b/Dramatic/Feature/Library/LibraryView.swift
@@ -10,5 +10,111 @@ import SnapKit
 
 final class LibraryView: BaseView {
     
+    private let scrollView = UIScrollView()
+    private let contentView = UIView()
+    
+    private let stackView = UIStackView()
+    let toWatchArchiveView = DTArchiveStatusView(title: "보고싶어요")
+    let watchedArchiveView = DTArchiveStatusView(title: "봤어요")
+    let watchingArchiveView = DTArchiveStatusView(title: "보는중", color: .dt(.semantic(.text(.brand))))
+    
+    private let toWatchHeader = DTHeader(title: "보고싶어요")
+    lazy var toWatchCollectionView = DTDramaHorizontalCollectionView(size: size)
+    
+    let watchedHeader = DTHeader(title: "봤어요")
+    lazy var watchedCollectionView = DTDramaHorizontalCollectionView(size: size)
+    
+    let watchingHeader = DTHeader(title: "보는중")
+    lazy var watchingCollectionView = DTDramaHorizontalCollectionView(size: size)
+    
+    let a = DTHeader(title: "보는중")
+    lazy var aCollectionView = DTDramaHorizontalCollectionView(size: size)
+    
+    private let size = DTDramaHorizontalCollectionView.DTCardType.drama
+    
+    override func configureHierarchy() {
+        stackView.addArrangedSubviews(
+            toWatchArchiveView,
+            watchedArchiveView,
+            watchingArchiveView
+        )
+        
+        contentView.addSubViews(
+            stackView,
+            toWatchHeader,
+            toWatchCollectionView,
+            watchedHeader,
+            watchedCollectionView,
+            watchingHeader,
+            watchingCollectionView,
+            a,
+            aCollectionView
+        )
+        
+        scrollView.addSubview(contentView)
+        
+        addSubview(scrollView)
+    }
+    
+    override func configureLayout() {
+        scrollView.snp.makeConstraints { make in
+            make.edges.equalTo(safeAreaLayoutGuide)
+        }
+
+        contentView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+            make.width.equalToSuperview()
+        }
+        
+        stackView.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(20)
+            make.horizontalEdges.equalToSuperview().inset(20)
+        }
+        
+        toWatchHeader.snp.makeConstraints { make in
+            make.top.equalTo(stackView.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview()
+        }
+
+        toWatchCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(toWatchHeader.snp.bottom).offset(10)
+            make.horizontalEdges.equalToSuperview()
+            make.height.equalTo(size.totalHeight)
+        }
+        
+        watchedHeader.snp.makeConstraints { make in
+            make.top.equalTo(toWatchCollectionView.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview()
+        }
+
+        watchedCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(watchedHeader.snp.bottom).offset(10)
+            make.horizontalEdges.equalToSuperview()
+            make.height.equalTo(size.totalHeight)
+        }
+        
+        watchingHeader.snp.makeConstraints { make in
+            make.top.equalTo(watchedCollectionView.snp.bottom).offset(30)
+            make.horizontalEdges.equalToSuperview()
+        }
+
+        watchingCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(watchingHeader.snp.bottom).offset(10)
+            make.horizontalEdges.equalToSuperview()
+            make.height.equalTo(size.totalHeight)
+            make.bottom.equalToSuperview().inset(30)
+        }
+        
+    }
+    
+    override func configureView() {
+        backgroundColor = .dt(.semantic(.bg(.primary)))
+        
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.showsHorizontalScrollIndicator = false
+        
+        stackView.axis = .horizontal
+        stackView.distribution = .fillEqually
+    }
     
 }

--- a/Dramatic/Feature/Library/LibraryView.swift
+++ b/Dramatic/Feature/Library/LibraryView.swift
@@ -1,0 +1,14 @@
+//
+//  LibraryView.swift
+//  Dramatic
+//
+//  Created by 이빈 on 3/24/25.
+//
+
+import UIKit
+import SnapKit
+
+final class LibraryView: BaseView {
+    
+    
+}

--- a/Dramatic/Feature/Library/LibraryViewController.swift
+++ b/Dramatic/Feature/Library/LibraryViewController.swift
@@ -68,7 +68,7 @@ extension LibraryViewController: View {
         
         // 셀 선택
         Observable.merge(
-            mainView.watchedCollectionView.collectionView.rx.modelddSelected(DramaDisplayable.self).asObservable(),
+            mainView.watchedCollectionView.collectionView.rx.modelSelected(DramaDisplayable.self).asObservable(),
             mainView.toWatchCollectionView.collectionView.rx.modelSelected(DramaDisplayable.self).asObservable(),
             mainView.watchingCollectionView.collectionView.rx.modelSelected(DramaDisplayable.self).asObservable()
         )

--- a/Dramatic/Feature/Library/LibraryViewController.swift
+++ b/Dramatic/Feature/Library/LibraryViewController.swift
@@ -6,10 +6,17 @@
 //
 
 import UIKit
-import SnapKit
+import RxSwift
+import ReactorKit
 
 final class LibraryViewController: BaseViewController<LibraryView> {
     
+    var disposeBag = DisposeBag()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.reactor = LibraryViewModel()
+    }
     
     override func configureNavigation() {
         let title = UILabel()
@@ -17,6 +24,65 @@ final class LibraryViewController: BaseViewController<LibraryView> {
         title.textColor = .dt(.semantic(.text(.primary)))
         title.font = .dt(.largeTitle)
         navigationItem.leftBarButtonItem = UIBarButtonItem(customView: title)
+    }
+
+}
+
+extension LibraryViewController: View {
+
+    func bind(reactor: LibraryViewModel) {
+        // 저장한 드라마
+        reactor.pulse(\.$toWatchDrama)
+            .bind(to: mainView.toWatchCollectionView.collectionView.rx.items(cellIdentifier: DTDramaHorizontalCollectionViewCell.identifier, cellType: DTDramaHorizontalCollectionViewCell.self)) { (row, element, cell) in
+                cell.configure(drama: element, cardType: DTDramaHorizontalCollectionView.DTCardType.drama)
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.pulse(\.$watchedDrama)
+            .bind(to: mainView.watchedCollectionView.collectionView.rx.items(cellIdentifier: DTDramaHorizontalCollectionViewCell.identifier, cellType: DTDramaHorizontalCollectionViewCell.self)) { (row, element, cell) in
+                cell.configure(drama: element, cardType: DTDramaHorizontalCollectionView.DTCardType.drama)
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.pulse(\.$watchingDrama)
+            .bind(to: mainView.watchingCollectionView.collectionView.rx.items(cellIdentifier: DTDramaHorizontalCollectionViewCell.identifier, cellType: DTDramaHorizontalCollectionViewCell.self)) { (row, element, cell) in
+                cell.configure(drama: element, cardType: DTDramaHorizontalCollectionView.DTCardType.drama)
+            }
+            .disposed(by: disposeBag)
+        
+        // 저장한 드라마 개수
+        reactor.state
+            .map { "\($0.toWatchCount)" }
+            .bind(to: mainView.toWatchArchiveView.countLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { "\($0.watchedCount)" }
+            .bind(to: mainView.watchedArchiveView.countLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { "\($0.watchingCount)" }
+            .bind(to: mainView.watchingArchiveView.countLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        // 셀 선택
+        Observable.merge(
+            mainView.watchedCollectionView.collectionView.rx.modelddSelected(DramaDisplayable.self).asObservable(),
+            mainView.toWatchCollectionView.collectionView.rx.modelSelected(DramaDisplayable.self).asObservable(),
+            mainView.watchingCollectionView.collectionView.rx.modelSelected(DramaDisplayable.self).asObservable()
+        )
+        .map { Reactor.Action.selectDrama(id: $0.id) }
+        .bind(to: reactor.action)
+        .disposed(by: disposeBag)
+        
+        // 화면 전환
+        reactor.state
+            .map { $0.selectedDrama }
+            .bind(with: self) { owner, id in
+                print("화면전환 아이디: \(id)")
+            }
+            .disposed(by: disposeBag)
     }
     
 }

--- a/Dramatic/Feature/Library/LibraryViewController.swift
+++ b/Dramatic/Feature/Library/LibraryViewController.swift
@@ -1,0 +1,22 @@
+//
+//  LibraryViewController.swift
+//  Dramatic
+//
+//  Created by 이빈 on 3/24/25.
+//
+
+import UIKit
+import SnapKit
+
+final class LibraryViewController: BaseViewController<LibraryView> {
+    
+    
+    override func configureNavigation() {
+        let title = UILabel()
+        title.text = "보관함"
+        title.textColor = .dt(.semantic(.text(.primary)))
+        title.font = .dt(.largeTitle)
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: title)
+    }
+    
+}

--- a/Dramatic/Feature/Library/LibraryViewModel.swift
+++ b/Dramatic/Feature/Library/LibraryViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  LibraryViewModel.swift
+//  Dramatic
+//
+//  Created by 이빈 on 3/25/25.
+//
+
+import Foundation

--- a/Dramatic/Feature/Library/LibraryViewModel.swift
+++ b/Dramatic/Feature/Library/LibraryViewModel.swift
@@ -6,3 +6,86 @@
 //
 
 import Foundation
+import RxSwift
+import ReactorKit
+
+final class LibraryViewModel: Reactor {
+    
+    enum Action {
+        case loadArchiveData
+        case loadArchiveCountData
+        case selectDrama(id: Int)
+    }
+    
+    enum Mutation {
+        case setToWatchDrama(dramas: [DramaDisplayable])
+        case setWatchedDrama(dramas: [DramaDisplayable])
+        case setWatchingDrama(dramas: [DramaDisplayable])
+        case setToWatchCount(count: Int)
+        case setWatchedCount(count: Int)
+        case setWatchingCount(count: Int)
+        case setSelectedDrama(id: Int)
+    }
+    
+    struct State {
+        @Pulse var toWatchDrama: [DramaDisplayable]
+        @Pulse var watchedDrama: [DramaDisplayable]
+        @Pulse var watchingDrama: [DramaDisplayable]
+        var toWatchCount: Int
+        var watchedCount: Int
+        var watchingCount: Int
+        var selectedDrama: Int?
+    }
+    
+    let initialState: State
+    
+    init() {
+        self.initialState = State(
+            toWatchDrama: [],
+            watchedDrama: [],
+            watchingDrama: [],
+            toWatchCount: 0,
+            watchedCount: 0,
+            watchingCount: 0
+        )
+        self.action.onNext(.loadArchiveData)
+        self.action.onNext(.loadArchiveCountData)
+    }
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .loadArchiveData:
+            // 렘에서 데이터 가져오기
+            return Observable.merge(
+                Observable.just(Mutation.setToWatchDrama(dramas: DramaEntity.mockEntities)),
+                Observable.just(Mutation.setWatchedDrama(dramas: DramaEntity.mockEntities)),
+                Observable.just(Mutation.setWatchingDrama(dramas: DramaEntity.mockEntities))
+            )
+            
+        case .loadArchiveCountData:
+            return Observable.merge(
+                Observable.just(Mutation.setToWatchCount(count: 37)),
+                Observable.just(Mutation.setWatchedCount(count: 22)),
+                Observable.just(Mutation.setWatchingCount(count: 43))
+            )
+            
+        case .selectDrama(let id):
+            return Observable.just(Mutation.setSelectedDrama(id: id))
+        }
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case .setToWatchDrama(let dramas): newState.toWatchDrama = dramas
+        case .setWatchedDrama(let dramas): newState.watchedDrama = dramas
+        case .setWatchingDrama(let dramas): newState.watchingDrama = dramas
+        case .setSelectedDrama(let id): newState.selectedDrama = id
+        case .setToWatchCount(let count): newState.toWatchCount = count
+        case .setWatchedCount(let count): newState.watchedCount = count
+        case .setWatchingCount(let count): newState.watchingCount = count
+        }
+        return newState
+    }
+    
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #20 

## 📝작업 내용
### **DTArchiveStatusView**
`보관 상태`와 `보관 개수`를 나타내는 컴포넌트 뷰를 구현했습니다.
기본 컬러는 회색으로, 생성할 때, 특정 컬러를 지정할 수 있도록 하였습니다.
```Swift
let watchedArchiveView = DTArchiveStatusView(title: "봤어요") // 회색
let watchingArchiveView = DTArchiveStatusView(title: "보는중", color: .dt(.semantic(.text(.brand))))
```

### **보관함 화면**
- 보고 싶어요 -> `toWatch`
- 봤어요 -> `watched`
- 보는중 -> `watching`
위 세 가지 상태에 대한 컬렉션뷰를 구현했습니다.

### **보관함 뷰모델**
렘에서 데이터를 가져오는 작업은 현재 더미 데이터를 적용해 놓았습니다.
`loadArchiveData`액션을 통해, 렘에서 사용자가 저장한 데이터를 가져옵니다. -> 컬렉션뷰에 할당
`loadArchiveCountData` 액션을 통해, 렘에서 사용자의 저장 상태에 대한 개수를 가져옵니다. -> `DTArchiveStatusView`의 `countLabel`에 할당

### 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/613efbc7-3f47-4483-b460-c842df48c6fe" width="300" />

## 💬리뷰 요구사항(선택)


close #20 
